### PR TITLE
feat: add toggle to expand details in comment by default

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -22,3 +22,4 @@ jobs:
           uses: ./
           with:
             json-file: test-data/tf_test.json
+            expand-comment: true

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   expand-comment:
     description: If true, expand the details comment by default
     required: false
-    default: 'false'
+    default: false
 runs:
   using: node16
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: GitHub Token
     required: false
     default: '${{github.token}}'
+  expand-comment:
+    description: If true, expand the details comment by default
+    required: false
+    default: 'false'
 runs:
   using: node16
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -11730,7 +11730,7 @@ function fileComment(inputFile, showFileName) {
         changes.filter(obj => obj.change.actions[0] === "delete").length + ' to destroy.</b>'
 
     let openDetails = ""
-    if (expandDetailsComment === false) {
+    if (expandDetailsComment === true) {
         openDetails = "open"
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -11682,6 +11682,7 @@ const trackedChanges = {
     "update": "!"
 }
 
+const expandDetailsComment = core.getInput('expand-comment');
 const myToken = core.getInput('github-token');
 const octokit = github.getOctokit(myToken);
 
@@ -11719,10 +11720,12 @@ function fileComment(inputFile, showFileName) {
         changes.filter(obj => obj.change.actions[0] === "update").length + ' to change, ' +
         changes.filter(obj => obj.change.actions[0] === "delete").length + ' to destroy.</b>'
 
+    let openDetails = expandDetailsComment ? "open" : ""
+
     let output = showFileName ? `\`${inputFile}\`` : ""
 
     output += `
-<details><summary>${summary}</summary>
+<details ${openDetails}><summary>${summary}</summary>
 ${message}
 </details>
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -11691,7 +11691,7 @@ const trackedChanges = {
     "update": "!"
 }
 
-const expandDetailsComment = core.getInput('expand-comment');
+const expandDetailsComment = core.getBooleanInput('expand-comment');
 const myToken = core.getInput('github-token');
 const octokit = github.getOctokit(myToken);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -11730,7 +11730,7 @@ function fileComment(inputFile, showFileName) {
         changes.filter(obj => obj.change.actions[0] === "delete").length + ' to destroy.</b>'
 
     let openDetails = ""
-    if (expandDetailsComment) {
+    if (expandDetailsComment === false) {
         openDetails = "open"
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -11447,6 +11447,14 @@ module.exports = require("buffer");
 
 /***/ }),
 
+/***/ 2057:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("constants");
+
+/***/ }),
+
 /***/ 2361:
 /***/ ((module) => {
 
@@ -11674,6 +11682,7 @@ var __webpack_exports__ = {};
 (() => {
 const core = __nccwpck_require__(2186);
 const github = __nccwpck_require__(5438);
+const exp = __nccwpck_require__(2057);
 const fs = __nccwpck_require__(7147);
 
 const trackedChanges = {
@@ -11720,7 +11729,10 @@ function fileComment(inputFile, showFileName) {
         changes.filter(obj => obj.change.actions[0] === "update").length + ' to change, ' +
         changes.filter(obj => obj.change.actions[0] === "delete").length + ' to destroy.</b>'
 
-    let openDetails = expandDetailsComment ? "open" : ""
+    let openDetails = ""
+    if (expandDetailsComment) {
+        openDetails = "open"
+    }
 
     let output = showFileName ? `\`${inputFile}\`` : ""
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const trackedChanges = {
     "update": "!"
 }
 
-const expandDetailsComment = core.getInput('expand-comment');
+const expandDetailsComment = core.getBooleanInput('expand-comment');
 const myToken = core.getInput('github-token');
 const octokit = github.getOctokit(myToken);
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
+const exp = require('constants');
 const fs = require('fs');
 
 const trackedChanges = {
@@ -46,7 +47,10 @@ function fileComment(inputFile, showFileName) {
         changes.filter(obj => obj.change.actions[0] === "update").length + ' to change, ' +
         changes.filter(obj => obj.change.actions[0] === "delete").length + ' to destroy.</b>'
 
-    let openDetails = expandDetailsComment ? "open" : ""
+    let openDetails = ""
+    if (expandDetailsComment) {
+        openDetails = "open"
+    }
 
     let output = showFileName ? `\`${inputFile}\`` : ""
 

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function fileComment(inputFile, showFileName) {
         changes.filter(obj => obj.change.actions[0] === "delete").length + ' to destroy.</b>'
 
     let openDetails = ""
-    if (expandDetailsComment) {
+    if (expandDetailsComment === false) {
         openDetails = "open"
     }
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const trackedChanges = {
     "update": "!"
 }
 
+const expandDetailsComment = core.getInput('expand-comment');
 const myToken = core.getInput('github-token');
 const octokit = github.getOctokit(myToken);
 
@@ -45,10 +46,12 @@ function fileComment(inputFile, showFileName) {
         changes.filter(obj => obj.change.actions[0] === "update").length + ' to change, ' +
         changes.filter(obj => obj.change.actions[0] === "delete").length + ' to destroy.</b>'
 
+    let openDetails = expandDetailsComment ? "open" : ""
+
     let output = showFileName ? `\`${inputFile}\`` : ""
 
     output += `
-<details><summary>${summary}</summary>
+<details ${openDetails}><summary>${summary}</summary>
 ${message}
 </details>
 

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function fileComment(inputFile, showFileName) {
         changes.filter(obj => obj.change.actions[0] === "delete").length + ' to destroy.</b>'
 
     let openDetails = ""
-    if (expandDetailsComment === false) {
+    if (expandDetailsComment === true) {
         openDetails = "open"
     }
 


### PR DESCRIPTION
This update will add an input flag that will default expand the comment details beneath the change summary.
Closes #16 