### PR TITLE
Creating catalog-info.yaml for Backstage Auto Discovery

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,35 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: liatrio/terraform-change-pr-commenter
+  # description: Add a useful description before merging
+
+  # Annotations Docs: https://backstage.io/docs/features/software-catalog/well-known-annotations
+  annotations:
+    github.com/project-slug: liatrio/terraform-change-pr-commenter
+
+  # Tags Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/#metadatatags-optional
+  tags:
+    - javascript
+    - terraform
+    - github-action
+
+  # Links Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/#links-optional
+  # links:
+  #   - url: https://example.com/user
+  #     title: Examples Users
+  #     icon: user
+  #   - url: https://example.com/group
+  #     title: Example Group
+  #     icon: group
+
+spec:
+  # https://backstage.io/docs/features/software-catalog/descriptor-format/#spectype-required
+  type: service
+  # Review lifecycle and pick one of the three that make the most sense.
+  # https://backstage.io/docs/features/software-catalog/descriptor-format/#speclifecycle-required
+  lifecycle: production
+  # Please update to include the GitHub Team name tied to this project.
+  # https://backstage.io/docs/features/software-catalog/descriptor-format/#specowner-required
+  owner: liatrio-team-members
+


### PR DESCRIPTION
❗ This is not ready to merge. Please review the changeset and update based on your repository. ❗

Please give the catalog-info.yaml a review. It could use tags, links, a description and the correct owner. Each section has links to the related documentation.

Review the [catalog-info.yaml docs](https://backstage.io/docs/features/software-catalog/descriptor-format/)
Check out an example of our implementation in [gratibot](https://github.com/liatrio/gratibot/blob/main/catalog-info.yaml)

After you've finished and merged, this repository will auto discover in the Liatrio Backstage instance.

For any questions, please reach out on our Slack channel: #project-backstage-foundations