### PR TITLE
fix: version bump for node to 20

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
       - run: yarn install
       - run: yarn run build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
       
       - name: Install Dependencies
         run: yarn install

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/liatrio/terraform-change-pr-commenter.git"
   },
   "engines": {
-    "node": ">=16"
+    "node": "20"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
Bumping node version to 20 from 16 in response to [Github Post](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20) and [issue 48](https://github.com/liatrio/terraform-change-pr-commenter/issues/48)