### PR TITLE
feat: Add tags tracking, unchanged resources, and matrix support for jobs

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -49,3 +49,31 @@ jobs:
         uses: ./
         with:
           json-file: test-data/tf_nochanges.json
+    
+  matrix-plan:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        json:
+          - tf_test4
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: yarn install
+      - run: yarn run build
+
+      - name: Test PR Commenter with matrix job
+        uses: ./
+        with:
+          json-file: test-data/${{ matrix.json }}.json
+          comment-header: Plan Summary for ${{ github.job }} (${{ matrix.json }})
+          quiet: true
+          expand-comment: true
+          hide-previous-comments: true
+          include-workflow-link: true
+          include-job-link: true
+          include-plan-job-summary: true
+          include-tag-only-resources: true
+          include-unchanged-resources: true

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,14 @@ inputs:
     description: Log the changed resources in action output
     required: false
     default: "true"
+  include-tag-only-resources:
+    description: If true, include resources with only tag changes as a separate section
+    required: false
+    default: "false"
+  include-unchanged-resources:
+    description: If true, include unchanged resources in the output
+    required: false
+    default: "false"
 runs:
   using: node20
   main: dist/index.js

--- a/index.js
+++ b/index.js
@@ -15,9 +15,13 @@ const includeLinkToWorkflow = core.getBooleanInput("include-workflow-link");
 const includeLinkToJob = core.getBooleanInput("include-job-link");
 const hidePreviousComments = core.getBooleanInput("hide-previous-comments");
 const logChangedResources = core.getBooleanInput("log-changed-resources");
+const includeTagOnlyResources = core.getBooleanInput("include-tag-only-resources");
+const includeUnchangedResources = core.getBooleanInput("include-unchanged-resources");
+
 
 // Get current job name from GitHub environment variable
 const currentJobName = process.env.GITHUB_JOB || '';
+const currentRunnerName = process.env.RUNNER_NAME || '';
 
 // Log the job name for debugging
 console.log('Current job name:', currentJobName);
@@ -39,20 +43,24 @@ async function getJobId() {
       const response = await octokit.rest.actions.listJobsForWorkflowRun({
         owner: context.repo.owner,
         repo: context.repo.repo,
-        run_id: context.runId
+        run_id: context.runId,
       });
       
       // Find the current job by name
-      const job = response.data.jobs.find(job => job.name === currentJobName);
+      const job = response.data.jobs.find(job => 
+        job.runner_name === currentRunnerName &&
+        (job.name.endsWith(currentJobName) || job.name.startsWith(currentJobName))
+      );
       
       if (job) {
-        console.log(`Found job ID: ${job.id} for job name: ${currentJobName}`);
+        console.log(`Found job ID: ${job.id} for job name: ${job.name}`);
         // Create job link with the numeric job ID
         return `
-[Job: ${currentJobName}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/job/${job.id})
+[Job: ${job.name}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/job/${job.id})
 `;
       } else {
         console.log(`Could not find job with name: ${currentJobName}`);
+        console.log(`Jobs: \n${JSON.stringify(response.data.jobs, null, 2)}`);
         return "";
       }
     } catch (error) {
@@ -108,7 +116,24 @@ const output = () => {
           resources_to_update = [],
           resources_to_delete = [],
           resources_to_replace = [],
+          resources_to_tag = [],
           resources_unchanged = [];
+
+        // Deep comparison function to check if objects are identical after removing tags
+        const isTagOnlyChange = (before, after) => {
+          if (includeTagOnlyResources == false) {
+            return false;
+          }
+          const beforeCopy = JSON.parse(JSON.stringify(before || {}));
+          const afterCopy = JSON.parse(JSON.stringify(after || {}));
+
+          delete beforeCopy.tags;
+          delete beforeCopy.tags_all;
+          delete afterCopy.tags;
+          delete afterCopy.tags_all;
+
+          return JSON.stringify(beforeCopy) === JSON.stringify(afterCopy);
+        };
 
         // for each resource changes
         for (const resource of resource_changes) {
@@ -132,7 +157,11 @@ const output = () => {
               }
               break;
             case "update":
-              resources_to_update.push(address);
+              if (isTagOnlyChange(change.before, change.after)) {
+                resources_to_tag.push(address);
+              } else {
+                resources_to_update.push(address);
+              }
               break;
           }
         }
@@ -143,11 +172,13 @@ const output = () => {
 ${commentHeader}
 <details ${expandDetailsComment ? "open" : ""}>
 <summary>
-<b>Terraform Plan: ${resources_to_create.length} to be created, ${resources_to_delete.length} to be deleted, ${resources_to_update.length} to be updated, ${resources_to_replace.length} to be replaced, ${resources_unchanged.length} unchanged.</b>
+<b>Terraform Plan: ${resources_to_create.length} to be created, ${resources_to_delete.length} to be deleted, ${resources_to_update.length} to be updated${includeTagOnlyResources ? `, ${resources_to_tag.length} to be tagged` : ''}, ${resources_to_replace.length} to be replaced, ${resources_unchanged.length} unchanged.</b>
 </summary>
+${includeUnchangedResources ? details("unchanged", resources_unchanged, "•") : ""}
 ${details("create", resources_to_create, "+")}
 ${details("delete", resources_to_delete, "-")}
 ${details("update", resources_to_update, "!")}
+${includeTagOnlyResources ? details("tag", resources_to_tag, "!") : ""}
 ${details("replace", resources_to_replace, "+")}
 </details>
 ${commentFooter.map((a) => (a == "" ? "\n" : a)).join("\n")}
@@ -158,6 +189,7 @@ ${jobLink}
           resources_to_create +
             resources_to_delete +
             resources_to_update +
+            resources_to_tag +
             resources_to_replace ==
           []
         ) {
@@ -183,11 +215,17 @@ ${jobLink}
 };
 
 const details = (action, resources, operator) => {
+  let str_title = "";
   let str = "";
 
   if (resources.length !== 0) {
+    if (action === "unchanged") {
+      str_title = "Unchanged resources";
+    } else {
+      str_title = `Resources to ${action}`;
+    }
     str = `
-#### Resources to ${action}\n
+#### ${str_title}\n
 \`\`\`diff\n
 `;
     for (const el of resources) {

--- a/test-data/tf_test4.json
+++ b/test-data/tf_test4.json
@@ -1,0 +1,1146 @@
+{
+  "format_version": "1.1",
+  "terraform_version": "1.2.9",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_iam_policy.changed",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "changed",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "arn": "arn:aws:iam::123456789012:policy/test-policy-change",
+            "description": "",
+            "id": "arn:aws:iam::123456789012:policy/test-policy-change",
+            "name": "test-policy-change",
+            "name_prefix": "",
+            "path": "/",
+            "policy": "{\"Statement\":[{\"Action\":\"s3:*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+            "policy_id": "ANPAR2DEMO",
+            "tags": {},
+            "tags_all": {
+              "Source": "demo-aws-test",
+              "SourceVersion": "27NwiYBI3"
+            }
+          },
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          }
+        },
+        {
+          "address": "aws_iam_policy.created",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "created",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "description": null,
+            "name": "test-policy-created",
+            "path": "/",
+            "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+            "tags": null,
+            "tags_all": {
+              "Source": "demo-aws-test",
+              "SourceVersion": "27NwiYBI3"
+            }
+          },
+          "sensitive_values": {
+            "tags_all": {}
+          }
+        },
+        {
+          "address": "aws_iam_policy.tag_and_change",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "tag_and_change",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "arn": "arn:aws:iam::123456789012:policy/test-policy-tag-and-change",
+            "description": "",
+            "id": "arn:aws:iam::123456789012:policy/test-policy-tag-and-change",
+            "name": "test-policy-tag-and-change",
+            "name_prefix": "",
+            "path": "/",
+            "policy": "{\"Statement\":[{\"Action\":\"s3:*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+            "policy_id": "ANPAR2NUVQKSU5XSSXLPG",
+            "tags": {},
+            "tags_all": {
+              "Source": "demo-aws-test",
+              "SourceVersion": "27NwiYBI3"
+            }
+          },
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          }
+        },
+        {
+          "address": "aws_iam_policy.tag_only",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "tag_only",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "arn": "arn:aws:iam::123456789012:policy/test-policy-tag-only",
+            "description": "",
+            "id": "arn:aws:iam::123456789012:policy/test-policy-tag-only",
+            "name": "test-policy-tag-only",
+            "name_prefix": "",
+            "path": "/",
+            "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+            "policy_id": "ANPAR2NUVQKSYF3ZBGWIM",
+            "tags": {
+              "SourceVersion": "27NwiYBI6"
+            },
+            "tags_all": {
+              "Source": "demo-aws-test",
+              "SourceVersion": "27NwiYBI6"
+            }
+          },
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          }
+        },
+        {
+          "address": "aws_iam_policy.tainted",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "tainted",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "description": null,
+            "name": "test-policy-tainted",
+            "path": "/",
+            "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+            "tags": null,
+            "tags_all": {
+              "Source": "demo-aws-test",
+              "SourceVersion": "27NwiYBI3"
+            }
+          },
+          "sensitive_values": {
+            "tags_all": {}
+          }
+        },
+        {
+          "address": "aws_iam_policy.unchanged",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "unchanged",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "arn": "arn:aws:iam::123456789012:policy/test-policy-unchanged",
+            "description": "",
+            "id": "arn:aws:iam::123456789012:policy/test-policy-unchanged",
+            "name": "test-policy-unchanged",
+            "name_prefix": "",
+            "path": "/",
+            "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+            "policy_id": "ANPAR2NUVQKSU2IBZAFHO",
+            "tags": {},
+            "tags_all": {
+              "Source": "demo-aws-test",
+              "SourceVersion": "27NwiYBI3"
+            }
+          },
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          }
+        },
+        {
+          "address": "random_string.version",
+          "mode": "managed",
+          "type": "random_string",
+          "name": "version",
+          "provider_name": "registry.terraform.io/hashicorp/random",
+          "schema_version": 2,
+          "values": {
+            "id": "27NwiYBI",
+            "keepers": null,
+            "length": 8,
+            "lower": true,
+            "min_lower": 0,
+            "min_numeric": 0,
+            "min_special": 0,
+            "min_upper": 0,
+            "number": true,
+            "numeric": true,
+            "override_special": null,
+            "result": "27NwiYBI",
+            "special": false,
+            "upper": true
+          },
+          "sensitive_values": {}
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "aws_iam_policy.changed",
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "changed",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "arn": "arn:aws:iam::123456789012:policy/test-policy-change",
+          "description": "",
+          "id": "arn:aws:iam::123456789012:policy/test-policy-change",
+          "name": "test-policy-change",
+          "name_prefix": "",
+          "path": "/",
+          "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+          "policy_id": "ANPAR2DEMO",
+          "tags": {},
+          "tags_all": {
+            "Source": "demo-aws-test",
+            "SourceVersion": "27NwiYBI3"
+          }
+        },
+        "after": {
+          "arn": "arn:aws:iam::123456789012:policy/test-policy-change",
+          "description": "",
+          "id": "arn:aws:iam::123456789012:policy/test-policy-change",
+          "name": "test-policy-change",
+          "name_prefix": "",
+          "path": "/",
+          "policy": "{\"Statement\":[{\"Action\":\"s3:*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+          "policy_id": "ANPAR2DEMO",
+          "tags": {},
+          "tags_all": {
+            "Source": "demo-aws-test",
+            "SourceVersion": "27NwiYBI3"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "tags": {},
+          "tags_all": {}
+        },
+        "after_sensitive": {
+          "tags": {},
+          "tags_all": {}
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy.created",
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "created",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": null,
+          "name": "test-policy-created",
+          "path": "/",
+          "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+          "tags": null,
+          "tags_all": {
+            "Source": "demo-aws-test",
+            "SourceVersion": "27NwiYBI3"
+          }
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true,
+          "name_prefix": true,
+          "policy_id": true,
+          "tags_all": {}
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "tags_all": {}
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy.destroyed",
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "destroyed",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "delete"
+        ],
+        "before": {
+          "arn": "arn:aws:iam::123456789012:policy/test-policy-destroyed",
+          "description": "",
+          "id": "arn:aws:iam::123456789012:policy/test-policy-destroyed",
+          "name": "test-policy-destroyed",
+          "name_prefix": "",
+          "path": "/",
+          "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+          "policy_id": "DEMOLIIFZ3",
+          "tags": {},
+          "tags_all": {
+            "Source": "demo-aws-test",
+            "SourceVersion": "27NwiYBI3"
+          }
+        },
+        "after": null,
+        "after_unknown": {},
+        "before_sensitive": {
+          "tags": {},
+          "tags_all": {}
+        },
+        "after_sensitive": false
+      },
+      "action_reason": "delete_because_no_resource_config"
+    },
+    {
+      "address": "aws_iam_policy.tag_and_change",
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "tag_and_change",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "arn": "arn:aws:iam::123456789012:policy/test-policy-tag-and-change",
+          "description": "",
+          "id": "arn:aws:iam::123456789012:policy/test-policy-tag-and-change",
+          "name": "test-policy-tag-and-change",
+          "name_prefix": "",
+          "path": "/",
+          "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+          "policy_id": "ANPAR2NUVQKSU5XSSXLPG",
+          "tags": {
+            "SourceVersion": "27NwiYBI6"
+          },
+          "tags_all": {
+            "Source": "demo-aws-test",
+            "SourceVersion": "27NwiYBI6"
+          }
+        },
+        "after": {
+          "arn": "arn:aws:iam::123456789012:policy/test-policy-tag-and-change",
+          "description": "",
+          "id": "arn:aws:iam::123456789012:policy/test-policy-tag-and-change",
+          "name": "test-policy-tag-and-change",
+          "name_prefix": "",
+          "path": "/",
+          "policy": "{\"Statement\":[{\"Action\":\"s3:*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+          "policy_id": "ANPAR2NUVQKSU5XSSXLPG",
+          "tags": {},
+          "tags_all": {
+            "Source": "demo-aws-test",
+            "SourceVersion": "27NwiYBI3"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "tags": {},
+          "tags_all": {}
+        },
+        "after_sensitive": {
+          "tags": {},
+          "tags_all": {}
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy.tag_only",
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "tag_only",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "arn": "arn:aws:iam::123456789012:policy/test-policy-tag-only",
+          "description": "",
+          "id": "arn:aws:iam::123456789012:policy/test-policy-tag-only",
+          "name": "test-policy-tag-only",
+          "name_prefix": "",
+          "path": "/",
+          "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+          "policy_id": "ANPAR2NUVQKSYF3ZBGWIM",
+          "tags": {},
+          "tags_all": {
+            "Source": "demo-aws-test",
+            "SourceVersion": "27NwiYBI3"
+          }
+        },
+        "after": {
+          "arn": "arn:aws:iam::123456789012:policy/test-policy-tag-only",
+          "description": "",
+          "id": "arn:aws:iam::123456789012:policy/test-policy-tag-only",
+          "name": "test-policy-tag-only",
+          "name_prefix": "",
+          "path": "/",
+          "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+          "policy_id": "ANPAR2NUVQKSYF3ZBGWIM",
+          "tags": {
+            "SourceVersion": "27NwiYBI6"
+          },
+          "tags_all": {
+            "Source": "demo-aws-test",
+            "SourceVersion": "27NwiYBI6"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "tags": {},
+          "tags_all": {}
+        },
+        "after_sensitive": {
+          "tags": {},
+          "tags_all": {}
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy.tainted",
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "tainted",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "delete",
+          "create"
+        ],
+        "before": {
+          "arn": "arn:aws:iam::123456789012:policy/test-policy-tainted",
+          "description": "",
+          "id": "arn:aws:iam::123456789012:policy/test-policy-tainted",
+          "name": "test-policy-tainted",
+          "name_prefix": "",
+          "path": "/",
+          "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+          "policy_id": "ANPAR2NUVQKSV46NWXCIW",
+          "tags": {},
+          "tags_all": {
+            "Source": "demo-aws-test",
+            "SourceVersion": "27NwiYBI3"
+          }
+        },
+        "after": {
+          "description": null,
+          "name": "test-policy-tainted",
+          "path": "/",
+          "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+          "tags": null,
+          "tags_all": {
+            "Source": "demo-aws-test",
+            "SourceVersion": "27NwiYBI3"
+          }
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true,
+          "name_prefix": true,
+          "policy_id": true,
+          "tags_all": {}
+        },
+        "before_sensitive": {
+          "tags": {},
+          "tags_all": {}
+        },
+        "after_sensitive": {
+          "tags_all": {}
+        }
+      },
+      "action_reason": "replace_because_tainted"
+    },
+    {
+      "address": "aws_iam_policy.unchanged",
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "unchanged",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "arn": "arn:aws:iam::123456789012:policy/test-policy-unchanged",
+          "description": "",
+          "id": "arn:aws:iam::123456789012:policy/test-policy-unchanged",
+          "name": "test-policy-unchanged",
+          "name_prefix": "",
+          "path": "/",
+          "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+          "policy_id": "ANPAR2NUVQKSU2IBZAFHO",
+          "tags": {},
+          "tags_all": {
+            "Source": "demo-aws-test",
+            "SourceVersion": "27NwiYBI3"
+          }
+        },
+        "after": {
+          "arn": "arn:aws:iam::123456789012:policy/test-policy-unchanged",
+          "description": "",
+          "id": "arn:aws:iam::123456789012:policy/test-policy-unchanged",
+          "name": "test-policy-unchanged",
+          "name_prefix": "",
+          "path": "/",
+          "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+          "policy_id": "ANPAR2NUVQKSU2IBZAFHO",
+          "tags": {},
+          "tags_all": {
+            "Source": "demo-aws-test",
+            "SourceVersion": "27NwiYBI3"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "tags": {},
+          "tags_all": {}
+        },
+        "after_sensitive": {
+          "tags": {},
+          "tags_all": {}
+        }
+      }
+    },
+    {
+      "address": "random_string.version",
+      "mode": "managed",
+      "type": "random_string",
+      "name": "version",
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "27NwiYBI",
+          "keepers": null,
+          "length": 8,
+          "lower": true,
+          "min_lower": 0,
+          "min_numeric": 0,
+          "min_special": 0,
+          "min_upper": 0,
+          "number": true,
+          "numeric": true,
+          "override_special": null,
+          "result": "27NwiYBI",
+          "special": false,
+          "upper": true
+        },
+        "after": {
+          "id": "27NwiYBI",
+          "keepers": null,
+          "length": 8,
+          "lower": true,
+          "min_lower": 0,
+          "min_numeric": 0,
+          "min_special": 0,
+          "min_upper": 0,
+          "number": true,
+          "numeric": true,
+          "override_special": null,
+          "result": "27NwiYBI",
+          "special": false,
+          "upper": true
+        },
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "1.0",
+    "terraform_version": "1.2.9",
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "aws_iam_policy.changed",
+            "mode": "managed",
+            "type": "aws_iam_policy",
+            "name": "changed",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "arn": "arn:aws:iam::123456789012:policy/test-policy-change",
+              "description": "",
+              "id": "arn:aws:iam::123456789012:policy/test-policy-change",
+              "name": "test-policy-change",
+              "name_prefix": "",
+              "path": "/",
+              "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+              "policy_id": "ANPAR2DEMO",
+              "tags": {},
+              "tags_all": {
+                "Source": "demo-aws-test",
+                "SourceVersion": "27NwiYBI3"
+              }
+            },
+            "sensitive_values": {
+              "tags": {},
+              "tags_all": {}
+            },
+            "depends_on": [
+              "data.aws_iam_policy_document.change",
+              "random_string.version"
+            ]
+          },
+          {
+            "address": "aws_iam_policy.destroyed",
+            "mode": "managed",
+            "type": "aws_iam_policy",
+            "name": "destroyed",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "arn": "arn:aws:iam::123456789012:policy/test-policy-destroyed",
+              "description": "",
+              "id": "arn:aws:iam::123456789012:policy/test-policy-destroyed",
+              "name": "test-policy-destroyed",
+              "name_prefix": "",
+              "path": "/",
+              "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+              "policy_id": "DEMOLIIFZ3",
+              "tags": {},
+              "tags_all": {
+                "Source": "demo-aws-test",
+                "SourceVersion": "27NwiYBI3"
+              }
+            },
+            "sensitive_values": {
+              "tags": {},
+              "tags_all": {}
+            },
+            "depends_on": [
+              "data.aws_iam_policy_document.unchanged",
+              "random_string.version"
+            ]
+          },
+          {
+            "address": "aws_iam_policy.tag_and_change",
+            "mode": "managed",
+            "type": "aws_iam_policy",
+            "name": "tag_and_change",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "arn": "arn:aws:iam::123456789012:policy/test-policy-tag-and-change",
+              "description": "",
+              "id": "arn:aws:iam::123456789012:policy/test-policy-tag-and-change",
+              "name": "test-policy-tag-and-change",
+              "name_prefix": "",
+              "path": "/",
+              "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+              "policy_id": "ANPAR2NUVQKSU5XSSXLPG",
+              "tags": {
+                "SourceVersion": "27NwiYBI6"
+              },
+              "tags_all": {
+                "Source": "demo-aws-test",
+                "SourceVersion": "27NwiYBI6"
+              }
+            },
+            "sensitive_values": {
+              "tags": {},
+              "tags_all": {}
+            },
+            "depends_on": [
+              "data.aws_iam_policy_document.change",
+              "random_string.version"
+            ]
+          },
+          {
+            "address": "aws_iam_policy.tag_only",
+            "mode": "managed",
+            "type": "aws_iam_policy",
+            "name": "tag_only",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "arn": "arn:aws:iam::123456789012:policy/test-policy-tag-only",
+              "description": "",
+              "id": "arn:aws:iam::123456789012:policy/test-policy-tag-only",
+              "name": "test-policy-tag-only",
+              "name_prefix": "",
+              "path": "/",
+              "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+              "policy_id": "ANPAR2NUVQKSYF3ZBGWIM",
+              "tags": {},
+              "tags_all": {
+                "Source": "demo-aws-test",
+                "SourceVersion": "27NwiYBI3"
+              }
+            },
+            "sensitive_values": {
+              "tags": {},
+              "tags_all": {}
+            },
+            "depends_on": [
+              "data.aws_iam_policy_document.unchanged",
+              "random_string.version"
+            ]
+          },
+          {
+            "address": "aws_iam_policy.tainted",
+            "mode": "managed",
+            "type": "aws_iam_policy",
+            "name": "tainted",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "arn": "arn:aws:iam::123456789012:policy/test-policy-tainted",
+              "description": "",
+              "id": "arn:aws:iam::123456789012:policy/test-policy-tainted",
+              "name": "test-policy-tainted",
+              "name_prefix": "",
+              "path": "/",
+              "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+              "policy_id": "ANPAR2NUVQKSV46NWXCIW",
+              "tags": {},
+              "tags_all": {
+                "Source": "demo-aws-test",
+                "SourceVersion": "27NwiYBI3"
+              }
+            },
+            "sensitive_values": {
+              "tags": {},
+              "tags_all": {}
+            },
+            "depends_on": [
+              "data.aws_iam_policy_document.unchanged",
+              "random_string.version"
+            ],
+            "tainted": true
+          },
+          {
+            "address": "aws_iam_policy.unchanged",
+            "mode": "managed",
+            "type": "aws_iam_policy",
+            "name": "unchanged",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "arn": "arn:aws:iam::123456789012:policy/test-policy-unchanged",
+              "description": "",
+              "id": "arn:aws:iam::123456789012:policy/test-policy-unchanged",
+              "name": "test-policy-unchanged",
+              "name_prefix": "",
+              "path": "/",
+              "policy": "{\"Statement\":[{\"Action\":\"s3:Get*\",\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"testdoc\"}],\"Version\":\"2012-10-17\"}",
+              "policy_id": "ANPAR2NUVQKSU2IBZAFHO",
+              "tags": {},
+              "tags_all": {
+                "Source": "demo-aws-test",
+                "SourceVersion": "27NwiYBI3"
+              }
+            },
+            "sensitive_values": {
+              "tags": {},
+              "tags_all": {}
+            },
+            "depends_on": [
+              "data.aws_iam_policy_document.unchanged",
+              "random_string.version"
+            ]
+          },
+          {
+            "address": "data.aws_iam_policy_document.change",
+            "mode": "data",
+            "type": "aws_iam_policy_document",
+            "name": "change",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "id": "1388270941",
+              "json": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"testdoc\",\n      \"Effect\": \"Allow\",\n      \"Action\": \"s3:*\",\n      \"Resource\": \"*\"\n    }\n  ]\n}",
+              "override_json": null,
+              "override_policy_documents": null,
+              "policy_id": null,
+              "source_json": null,
+              "source_policy_documents": null,
+              "statement": [
+                {
+                  "actions": [
+                    "s3:*"
+                  ],
+                  "condition": [],
+                  "effect": "Allow",
+                  "not_actions": [],
+                  "not_principals": [],
+                  "not_resources": [],
+                  "principals": [],
+                  "resources": [
+                    "*"
+                  ],
+                  "sid": "testdoc"
+                }
+              ],
+              "version": "2012-10-17"
+            },
+            "sensitive_values": {
+              "statement": [
+                {
+                  "actions": [
+                    false
+                  ],
+                  "condition": [],
+                  "not_actions": [],
+                  "not_principals": [],
+                  "not_resources": [],
+                  "principals": [],
+                  "resources": [
+                    false
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "address": "data.aws_iam_policy_document.unchanged",
+            "mode": "data",
+            "type": "aws_iam_policy_document",
+            "name": "unchanged",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "id": "1270208521",
+              "json": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"testdoc\",\n      \"Effect\": \"Allow\",\n      \"Action\": \"s3:Get*\",\n      \"Resource\": \"*\"\n    }\n  ]\n}",
+              "override_json": null,
+              "override_policy_documents": null,
+              "policy_id": null,
+              "source_json": null,
+              "source_policy_documents": null,
+              "statement": [
+                {
+                  "actions": [
+                    "s3:Get*"
+                  ],
+                  "condition": [],
+                  "effect": "Allow",
+                  "not_actions": [],
+                  "not_principals": [],
+                  "not_resources": [],
+                  "principals": [],
+                  "resources": [
+                    "*"
+                  ],
+                  "sid": "testdoc"
+                }
+              ],
+              "version": "2012-10-17"
+            },
+            "sensitive_values": {
+              "statement": [
+                {
+                  "actions": [
+                    false
+                  ],
+                  "condition": [],
+                  "not_actions": [],
+                  "not_principals": [],
+                  "not_resources": [],
+                  "principals": [],
+                  "resources": [
+                    false
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "address": "random_string.version",
+            "mode": "managed",
+            "type": "random_string",
+            "name": "version",
+            "provider_name": "registry.terraform.io/hashicorp/random",
+            "schema_version": 2,
+            "values": {
+              "id": "27NwiYBI",
+              "keepers": null,
+              "length": 8,
+              "lower": true,
+              "min_lower": 0,
+              "min_numeric": 0,
+              "min_special": 0,
+              "min_upper": 0,
+              "number": true,
+              "numeric": true,
+              "override_special": null,
+              "result": "27NwiYBI",
+              "special": false,
+              "upper": true
+            },
+            "sensitive_values": {}
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "full_name": "registry.terraform.io/hashicorp/aws",
+        "version_constraint": "~\u003e 4.0",
+        "expressions": {
+          "default_tags": [
+            {
+              "tags": {
+                "references": [
+                  "random_string.version.result",
+                  "random_string.version"
+                ]
+              }
+            }
+          ],
+          "region": {
+            "constant_value": "us-west-2"
+          }
+        }
+      },
+      "random": {
+        "name": "random",
+        "full_name": "registry.terraform.io/hashicorp/random"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_iam_policy.changed",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "changed",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "test-policy-change"
+            },
+            "policy": {
+              "references": [
+                "data.aws_iam_policy_document.change.json",
+                "data.aws_iam_policy_document.change"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy.created",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "created",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "test-policy-created"
+            },
+            "policy": {
+              "references": [
+                "data.aws_iam_policy_document.unchanged.json",
+                "data.aws_iam_policy_document.unchanged"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy.tag_and_change",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "tag_and_change",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "test-policy-tag-and-change"
+            },
+            "policy": {
+              "references": [
+                "data.aws_iam_policy_document.change.json",
+                "data.aws_iam_policy_document.change"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy.tag_only",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "tag_only",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "test-policy-tag-only"
+            },
+            "policy": {
+              "references": [
+                "data.aws_iam_policy_document.unchanged.json",
+                "data.aws_iam_policy_document.unchanged"
+              ]
+            },
+            "tags": {
+              "references": [
+                "random_string.version.result",
+                "random_string.version"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy.tainted",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "tainted",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "test-policy-tainted"
+            },
+            "policy": {
+              "references": [
+                "data.aws_iam_policy_document.unchanged.json",
+                "data.aws_iam_policy_document.unchanged"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy.unchanged",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "unchanged",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "test-policy-unchanged"
+            },
+            "policy": {
+              "references": [
+                "data.aws_iam_policy_document.unchanged.json",
+                "data.aws_iam_policy_document.unchanged"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "random_string.version",
+          "mode": "managed",
+          "type": "random_string",
+          "name": "version",
+          "provider_config_key": "random",
+          "expressions": {
+            "length": {
+              "constant_value": 8
+            },
+            "special": {
+              "constant_value": false
+            }
+          },
+          "schema_version": 2
+        },
+        {
+          "address": "data.aws_iam_policy_document.change",
+          "mode": "data",
+          "type": "aws_iam_policy_document",
+          "name": "change",
+          "provider_config_key": "aws",
+          "expressions": {
+            "statement": [
+              {
+                "actions": {
+                  "constant_value": [
+                    "s3:*"
+                  ]
+                },
+                "effect": {
+                  "constant_value": "Allow"
+                },
+                "resources": {
+                  "constant_value": [
+                    "*"
+                  ]
+                },
+                "sid": {
+                  "constant_value": "testdoc"
+                }
+              }
+            ]
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "data.aws_iam_policy_document.unchanged",
+          "mode": "data",
+          "type": "aws_iam_policy_document",
+          "name": "unchanged",
+          "provider_config_key": "aws",
+          "expressions": {
+            "statement": [
+              {
+                "actions": {
+                  "constant_value": [
+                    "s3:Get*"
+                  ]
+                },
+                "effect": {
+                  "constant_value": "Allow"
+                },
+                "resources": {
+                  "constant_value": [
+                    "*"
+                  ]
+                },
+                "sid": {
+                  "constant_value": "testdoc"
+                }
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  },
+  "relevant_attributes": [
+    {
+      "resource": "data.aws_iam_policy_document.change",
+      "attribute": [
+        "json"
+      ]
+    },
+    {
+      "resource": "data.aws_iam_policy_document.unchanged",
+      "attribute": [
+        "json"
+      ]
+    },
+    {
+      "resource": "random_string.version",
+      "attribute": [
+        "result"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces new functionality to enhance the Terraform Plan summary and improve the GitHub Actions workflow. The key changes include adding support for displaying tag-only and unchanged resources in the output, updating the job identification logic, and extending the GitHub Actions workflow with a matrix job for testing.

### Enhancements to Terraform Plan Summary:
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R51-R58): Added two new inputs, `include-tag-only-resources` and `include-unchanged-resources`, to control the inclusion of tag-only and unchanged resources in the output.
* `index.js`:
  * Introduced logic to detect tag-only changes by comparing resources after removing tags, and added these resources to a separate section (`resources_to_tag`). [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R119-R137) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R160-R164)
  * Updated the summary output to optionally include tag-only and unchanged resources based on the new inputs.
  * Enhanced the `details` function to dynamically generate section titles for different resource categories.

### Improvements to Job Identification:
* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L42-R63): Modified the `getJobId` function to improve job matching by considering the runner name and partial matches for job names. This ensures more accurate identification of the current job.

### Updates to GitHub Actions Workflow:
* [`.github/workflows/action-test.yml`](diffhunk://#diff-8412ec35d13f72ddd3f891b8ee4ae4c1247cdf02819bd761976f2909e33dfe14R52-R79): Introduced a new matrix job (`matrix-plan`) to test the action with multiple configurations, ensuring robust testing of the new features.