### PR TITLE
feat: Simplify comment-header logic and improve multi-file support

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           node -e "
             const output = process.env.COMMENT_BODY;
-            if (!output.includes('Terraform Plan Changes for test-data/tf_test.json')) {
+            if (!output.includes('Terraform Plan Changes for `test-data/tf_test.json`')) {
               console.error('Assertion failed: Missing header for tf_test.json');
               process.exit(1);
             }
@@ -96,11 +96,11 @@ jobs:
         run: |
           node -e "
             const output = process.env.COMMENT_BODY;
-            if (!output.includes('Terraform Plan Changes for test-data/tf_test.json')) {
+            if (!output.includes('Terraform Plan Changes for `test-data/tf_test.json`')) {
               console.error('Assertion failed: Missing header for tf_test.json');
               process.exit(1);
             }
-            if (!output.includes('Terraform Plan Changes for test-data/tf_test2.json')) {
+            if (!output.includes('Terraform Plan Changes for `test-data/tf_test2.json`')) {
               console.error('Assertion failed: Missing header for tf_test2.json');
               process.exit(1);
             }
@@ -122,11 +122,11 @@ jobs:
         run: |
           node -e "
             const output = process.env.COMMENT_BODY;
-            if (!output.includes('Terraform Plan Changes for test-data/tf_test.json')) {
+            if (!output.includes('Terraform Plan Changes for `test-data/tf_test.json`')) {
               console.error('Assertion failed: Missing header for tf_test.json');
               process.exit(1);
             }
-            if (!output.includes('Terraform Plan Changes for test-data/tf_test2.json')) {
+            if (!output.includes('Terraform Plan Changes for `test-data/tf_test2.json`')) {
               console.error('Assertion failed: Missing header for tf_test2.json');
               process.exit(1);
             }

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      - run: npm install -g yarn
       - run: yarn install
       - run: yarn run build
 
@@ -65,6 +66,30 @@ jobs:
         with:
           json-file: test-data/tf_noresources.json
 
+      - name: Test multiple json files
+        id: multiple_files
+        uses: ./
+        with:
+          json-file: |
+            test-data/tf_test.json
+            test-data/tf_test2.json
+
+      - name: Assert multiple json files output
+        run: |
+          node -e "
+            const output = process.env.COMMENT_BODY;
+            if (!output.includes('Terraform Plan Changes for test-data/tf_test.json')) {
+              console.error('Assertion failed: Missing header for tf_test.json');
+              process.exit(1);
+            }
+            if (!output.includes('Terraform Plan Changes for test-data/tf_test2.json')) {
+              console.error('Assertion failed: Missing header for tf_test2.json');
+              process.exit(1);
+            }
+          "
+        env:
+          COMMENT_BODY: ${{ steps.multiple_files.outputs.comment-body }}
+
   matrix-plan:
     runs-on: ubuntu-latest
     strategy:
@@ -76,6 +101,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      - run: npm install -g yarn
       - run: yarn install
       - run: yarn run build
 

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -66,6 +66,50 @@ jobs:
         with:
           json-file: test-data/tf_noresources.json
 
+      - name: Test PR comment hiding with default header
+        id: hide_default_header
+        uses: ./
+        with:
+          json-file: test-data/tf_test.json
+          hide-previous-comments: true
+      - name: Assert PR comment hiding with default header
+        run: |
+          node -e "
+            const output = process.env.COMMENT_BODY;
+            if (!output.includes('Terraform Plan Changes for test-data/tf_test.json')) {
+              console.error('Assertion failed: Missing header for tf_test.json');
+              process.exit(1);
+            }
+          "
+        env:
+          COMMENT_BODY: ${{ steps.hide_default_header.outputs.comment-body }}
+
+      - name: Test multiline json files with hide previous comments and default header
+        id: multiline_hide_default
+        uses: ./
+        with:
+          json-file: |
+            test-data/tf_test.json
+            test-data/tf_test2.json
+          hide-previous-comments: true
+      - name: Assert multiline json files with hide previous comments and default header
+        run: |
+          node -e "
+            const output = process.env.COMMENT_BODY;
+            if (!output.includes('Terraform Plan Changes for test-data/tf_test.json')) {
+              console.error('Assertion failed: Missing header for tf_test.json');
+              process.exit(1);
+            }
+            if (!output.includes('Terraform Plan Changes for test-data/tf_test2.json')) {
+              console.error('Assertion failed: Missing header for tf_test2.json');
+              process.exit(1);
+            }
+          "
+        env:
+          COMMENT_BODY: ${{ steps.multiline_hide_default.outputs.comment-body }}
+
+      
+
       - name: Test multiple json files
         id: multiple_files
         uses: ./

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Implementing this Action is _super_ simple and the comments are consise and easy
 
 **Optional** Defaults to `Terraform Plan Changes`
 
-- Will set the header of the PR comment and/or workflow summary.
+- Will set the header of the PR comment and/or workflow summary. The filename will always be appended to this header.
 
 ### `comment-footer`
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -12991,7 +12991,7 @@ const output = () => {
         // there will be formatting error when comment is
         // showed on GitHub
         body += `
-${commentHeader}
+${commentHeader} for \`${file}\`
 <details ${expandDetailsComment ? "open" : ""}>
 <summary>
 <b>Terraform Plan: ${resources_to_create.length} to be created, ${resources_to_delete.length} to be deleted, ${resources_to_update.length} to be updated${includeTagOnlyResources ? `, ${resources_to_tag.length} to be tagged` : ""}, ${resources_to_replace.length} to be replaced, ${resources_unchanged.length} unchanged.</b>
@@ -13107,6 +13107,14 @@ const hideComments = () => {
       );
 
       core.info(
+        `Filtered down to ${filteredComments.length} comments created by this action.`,
+      );
+
+      filteredComments = filteredComments.filter((comment) =>
+        comment.body.includes(commentHeader),
+      );
+
+      core.info(
         `Filtered down to ${filteredComments.length} comments that need to be minimized.`,
       );
 
@@ -13205,6 +13213,7 @@ async function run() {
       });
       core.info("Comment added successfully.");
     }
+    core.setOutput("comment-body", rawOutput);
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ const output = () => {
         // there will be formatting error when comment is
         // showed on GitHub
         body += `
-${commentHeader} for ${file}
+${commentHeader} for `${file}`
 <details ${expandDetailsComment ? "open" : ""}>
 <summary>
 <b>Terraform Plan: ${resources_to_create.length} to be created, ${resources_to_delete.length} to be deleted, ${resources_to_update.length} to be updated${includeTagOnlyResources ? `, ${resources_to_tag.length} to be tagged` : ""}, ${resources_to_replace.length} to be replaced, ${resources_unchanged.length} unchanged.</b>

--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ const output = () => {
         // there will be formatting error when comment is
         // showed on GitHub
         body += `
-${commentHeader}
+${commentHeader} for ${file}
 <details ${expandDetailsComment ? "open" : ""}>
 <summary>
 <b>Terraform Plan: ${resources_to_create.length} to be created, ${resources_to_delete.length} to be deleted, ${resources_to_update.length} to be updated${includeTagOnlyResources ? `, ${resources_to_tag.length} to be tagged` : ""}, ${resources_to_replace.length} to be replaced, ${resources_unchanged.length} unchanged.</b>
@@ -291,6 +291,14 @@ const hideComments = () => {
       );
 
       core.info(
+        `Filtered down to ${filteredComments.length} comments created by this action.`,
+      );
+
+      filteredComments = filteredComments.filter((comment) =>
+        comment.body.includes(commentHeader),
+      );
+
+      core.info(
         `Filtered down to ${filteredComments.length} comments that need to be minimized.`,
       );
 
@@ -389,6 +397,7 @@ async function run() {
       });
       core.info("Comment added successfully.");
     }
+    core.setOutput("comment-body", rawOutput);
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ const output = () => {
         // there will be formatting error when comment is
         // showed on GitHub
         body += `
-${commentHeader} for `${file}`
+${commentHeader} for \`${file}\`
 <details ${expandDetailsComment ? "open" : ""}>
 <summary>
 <b>Terraform Plan: ${resources_to_create.length} to be created, ${resources_to_delete.length} to be deleted, ${resources_to_update.length} to be updated${includeTagOnlyResources ? `, ${resources_to_tag.length} to be tagged` : ""}, ${resources_to_replace.length} to be replaced, ${resources_unchanged.length} unchanged.</b>


### PR DESCRIPTION
This commit simplifies the  logic by always appending the filename to the provided  (or its default value). This ensures that each Terraform plan output, even when multiple are processed, has a unique and descriptive header in the PR comment.

The  functionality remains intact as it relies on , which will still match the base header string.

Changes include:
- Reverted  default in .
- Modified  to always append " for <filename>" to the comment header and reverted the input type.
- Updated  to reflect this simplified behavior.
- Added a new test case to  to specifically verify multi-file output with dynamic headers.

Addresses issue #90 